### PR TITLE
Fix deploy-to-pages.yml caching issue

### DIFF
--- a/.github/workflows/deploy-to-pages.yml
+++ b/.github/workflows/deploy-to-pages.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BUILD_PATH: "./dist"
+  BUILD_PATH: "."
 
 jobs:
   build:
@@ -48,7 +48,7 @@ jobs:
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
-          cache-dependency-path: ${{ github.workspace }}/${{ steps.detect-package-manager.outputs.lockfile }}
+          cache-dependency-path: ${{ env.BUILD_PATH }}/${{ steps.detect-package-manager.outputs.lockfile }}
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"scripts": {
 		"dev": "npx tinacms dev -c \"astro dev\"",
 		"start": "astro dev",
-		"build": "pnpm astro build",
+		"build": "astro build",
 		"sync": "astro sync",
 		"preview": "astro preview",
 		"postbuild": "pagefind --site dist",


### PR DESCRIPTION
Update `deploy-to-pages.yml` and `package.json` to fix unresolved paths and caching dependencies.

* **package.json**
  - Update the `build` script to use `astro build` instead of `pnpm astro build`.

* **.github/workflows/deploy-to-pages.yml**
  - Update the `BUILD_PATH` environment variable to `.`.
  - Update the `cache-dependency-path` in the `Setup Node` step to `${{ env.BUILD_PATH }}/${{ steps.detect-package-manager.outputs.lockfile }}`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nirzaf/dotnetblogs?shareId=2a94d940-f4fc-49ba-a2f6-a80c0d08c7b0).